### PR TITLE
Fix Rect.create tuple case

### DIFF
--- a/source/miniworlds/positions/rect.py
+++ b/source/miniworlds/positions/rect.py
@@ -10,8 +10,7 @@ class Rect(pygame.Rect):
     @classmethod
     def create(cls, rect: Union[tuple, pygame.Rect]):
         if type(rect) == tuple:
-            cls(rect[0], rect[1], 1, 1)
-            return rect
+            return cls(rect[0], rect[1], 1, 1)
         elif type(rect) == pygame.Rect:
             return cls(rect.x, rect.y, rect.width, rect.height)
         else:


### PR DESCRIPTION
## Summary
- fix `Rect.create` when passing a tuple so it returns a `Rect`

## Testing
- `python -m py_compile source/miniworlds/positions/rect.py`
- `PYTHONPATH=source pytest test/test_000_template.py::test_running -q` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6846a09ac10c83309764f20dd7bfca2f